### PR TITLE
fix: explicit nullable types for Punchout Session model parameters

### DIFF
--- a/Model/Session.php
+++ b/Model/Session.php
@@ -137,7 +137,7 @@ class Session extends SessionManager implements SessionInterface
         Session\SessionEditStatus $editStatus,
         PunchoutQuoteRepositoryInterface $punchoutQuoteRepository,
         PunchoutQuoteInterfaceFactory $punchoutQuoteInterfaceFactory,
-        SessionStartChecker $sessionStartChecker = null
+        SessionStartChecker|null $sessionStartChecker = null
     ) {
         $this->logger = $logger;
         $this->sessionCollector = $sessionCollector;
@@ -306,7 +306,7 @@ class Session extends SessionManager implements SessionInterface
      *
      * login customer
      */
-    protected function loginCustomer(\Magento\Customer\Api\Data\CustomerInterface $customer = null)
+    protected function loginCustomer(\Magento\Customer\Api\Data\CustomerInterface|null $customer = null)
     {
         if ($customer && $customer->getId()) {
             $this->customerSession->loginById($customer->getId());


### PR DESCRIPTION
Resolves PHP 8+ deprecation warnings for implicit nullable parameters in Session::__construct() and Session::loginCustomer() methods.

Deprecation warnings preview:
<img width="1512" height="177" alt="image" src="https://github.com/user-attachments/assets/b22baaf8-9f6a-4f61-bdcf-01619c30d4b1" />
