### PR TITLE
[MAIN] CN-1162: Fix edit cart operation failing for products assigned to a shared catalog

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,8 @@
 TradeCentric - PunchOut
 ===========
+### 3.1.15 (2026-04-02)
+* CN-1162: Fixed edit cart operation failing for products assigned to a shared catalog
+
 ### 3.1.14 (2026-03-24)
 * PBR-2539: Refactored the window reload punchout configuration to remove double quote characters
 

--- a/Model/PunchoutSessionCollector/QuoteHandler.php
+++ b/Model/PunchoutSessionCollector/QuoteHandler.php
@@ -78,7 +78,6 @@ class QuoteHandler implements EntityHandlerInterface
         $this->logger->log('Quote Setup Begin');
         $object->getQuote()->setCustomer($object->getCustomer());
         $checkoutData = $this->dataExtractor->extract($object->getSession()->getParams());
-        $this->logger->log('checkoutData items: ' . json_encode($checkoutData['items']));
         foreach ($checkoutData['items'] as $item) {
             $this->logger->log(sprintf('Add item sku %s : quote_id\item_id %s', $item['sku'], $item['line_id']));
             $quoteItem = $this->getQuoteItem($item);

--- a/Model/PunchoutSessionCollector/QuoteHandler.php
+++ b/Model/PunchoutSessionCollector/QuoteHandler.php
@@ -78,6 +78,7 @@ class QuoteHandler implements EntityHandlerInterface
         $this->logger->log('Quote Setup Begin');
         $object->getQuote()->setCustomer($object->getCustomer());
         $checkoutData = $this->dataExtractor->extract($object->getSession()->getParams());
+        $this->logger->log('checkoutData items: ' . json_encode($checkoutData['items']));
         foreach ($checkoutData['items'] as $item) {
             $this->logger->log(sprintf('Add item sku %s : quote_id\item_id %s', $item['sku'], $item['line_id']));
             $quoteItem = $this->getQuoteItem($item);

--- a/Model/PunchoutSessionCollector/QuoteHandler/QuoteItemExtractor.php
+++ b/Model/PunchoutSessionCollector/QuoteHandler/QuoteItemExtractor.php
@@ -3,7 +3,8 @@ declare(strict_types=1);
 
 namespace Punchout2Go\Punchout\Model\PunchoutSessionCollector\QuoteHandler;
 
-use Magento\Framework\Exception\NoSuchEntityException;
+use Magento\Quote\Api\Data\CartItemInterface;
+use Magento\Quote\Model\ResourceModel\Quote\Item\CollectionFactory;
 
 /**
  * Class QuoteItemExtractor
@@ -17,35 +18,33 @@ class QuoteItemExtractor
     protected $items = [];
 
     /**
-     * @var \Magento\Quote\Api\CartItemRepositoryInterface
+     * @var CollectionFactory
      */
-    protected $cartItemRepository;
+    protected $itemCollectionFactory;
 
     /**
      * QuoteItemExtractor constructor.
-     * @param \Magento\Quote\Api\CartItemRepositoryInterface $cartItemRepository
+     * @param CollectionFactory $itemCollectionFactory
      */
-    public function __construct(\Magento\Quote\Api\CartItemRepositoryInterface $cartItemRepository)
-    {
-        $this->cartItemRepository = $cartItemRepository;
+    public function __construct(
+        CollectionFactory $itemCollectionFactory
+    ) {
+        $this->itemCollectionFactory = $itemCollectionFactory;
     }
 
     /**
      * @param $quoteId
      * @param $itemId
-     * @return \Magento\Quote\Api\Data\CartItemInterface|null
+     * @return CartItemInterface|null
      */
-    public function getQuoteItem($quoteId, $itemId): ?\Magento\Quote\Api\Data\CartItemInterface
+    public function getQuoteItem($quoteId, $itemId): ?CartItemInterface
     {
         if (isset($this->items[$quoteId][$itemId])) {
             return $this->items[$quoteId][$itemId];
         }
-        try {
-            $cartItems = $this->cartItemRepository->getList($quoteId);
-        } catch (NoSuchEntityException $e) {
-            return null;
-        }
-        foreach ($cartItems as $item) {
+        $collection = $this->itemCollectionFactory->create();
+        $collection->addFieldToFilter('quote_id', (int) $quoteId);
+        foreach ($collection as $item) {
             $this->items[$quoteId][$item->getItemId()] = $item;
         }
         return $this->items[$quoteId][$itemId] ?? null;

--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
     "config": {
         "sort-packages": true
     },
-    "version": "3.1.14",
+    "version": "3.1.15",
     "require": {
         "php": "~7.3.0||~7.4.0||^8.0",
         "tradecentric/module-version": "*",


### PR DESCRIPTION
Fix edit cart operation failing for products assigned to a shared catalog by replacing CartItemRepositoryInterface::getList() with a direct resource model collection query, bypassing Magento B2B shared catalog plugins that were blocking quote item access.