### PR TITLE
CN-1162 Fix products not being added to cart when assigned to a shared catalog

### DIFF
--- a/Model/PunchoutSessionCollector/QuoteHandler.php
+++ b/Model/PunchoutSessionCollector/QuoteHandler.php
@@ -119,9 +119,9 @@ class QuoteHandler implements EntityHandlerInterface
         try {
             $product = null;
             if ((int) $productId) {
-                $product = $this->productRepository->getById((int) $productId);
+                $product = $this->productRepository->getById((int) $productId, false, 0);
             } elseif ($sku) {
-                $product = $this->productRepository->getById((string) $sku);
+                $product = $this->productRepository->get((string) $sku, false, 0);
             }
         } catch (NoSuchEntityException $e) {
         }


### PR DESCRIPTION
CN-1162 fixed shared catalog filtering in QuoteItemExtractor but the same restriction applied when loading the product itself. Pass admin store scope to productRepository calls to bypass shared catalog filtering during punchout cart reconstruction. Also fixes incorrect use of getById() for SKU lookups, which should use get() instead.