### PR TITLE
[MAIN] CN-1161: bump module version in composer

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,8 @@
 TradeCentric - PunchOut
 ===========
+### 3.1.17 (2026-05-27)
+* Resolved PHP code sniffer violations
+
 ### 3.1.16 (2026-05-18)
 * PBR-2675: The object IDs remain consistent throughout a PunchOut session with edit operations, so the final POs use the correct IDs
 

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
             "dealerdirect/phpcodesniffer-composer-installer": true
         }
     },
-    "version": "3.1.16",
+    "version": "3.1.17",
     "require": {
         "php": "~7.3.0||~7.4.0||^8.0",
         "tradecentric/module-version": "*",


### PR DESCRIPTION
## Summary
- Bumps the module version in `composer.json` following the CN-1160/CN-1161 merge

## Test plan
- [ ] Verify `composer.json` version reflects the correct module version