### PR TITLE
[MAIN] 3.1.18 release prep: update CHANGELOG & bump composer version

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,7 +1,7 @@
 TradeCentric - PunchOut
 ===========
 ### 3.1.18 (2026-06-15)
-* Update CI/CD processes to reflect code sniffer changes
+* Updated CI/CD processes to reflect code sniffer changes
 * Fixed date of birth validation error causing PunchOut login failure on Magento v2.4.9
 
 ### 3.1.17 (2026-05-27)

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,9 @@
 TradeCentric - PunchOut
 ===========
+### 3.1.18 (2026-06-15)
+* Update CI/CD processes to reflect code sniffer changes
+* Fixed date of birth validation error causing PunchOut login failure on Magento v2.4.9
+
 ### 3.1.17 (2026-05-27)
 * Resolved PHP code sniffer violations
 

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
             "dealerdirect/phpcodesniffer-composer-installer": true
         }
     },
-    "version": "3.1.17",
+    "version": "3.1.18",
     "require": {
         "php": "~7.3.0||~7.4.0||^8.0",
         "tradecentric/module-version": "*",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "4c572a8f9d76b11a9cc21a388420078f",
+    "content-hash": "3cfbc0ea7fedcea65d435e6717130e80",
     "packages": [
         {
             "name": "tradecentric/module-version",
@@ -356,11 +356,11 @@
         },
         {
             "name": "phpstan/phpstan",
-            "version": "2.2.1",
+            "version": "2.2.2",
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/dea9c8f2d25cc849391042b71e429c1a4bf82660",
-                "reference": "dea9c8f2d25cc849391042b71e429c1a4bf82660",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/e5cc34d491a90e79c216d824f60fe21fd4d93bd6",
+                "reference": "e5cc34d491a90e79c216d824f60fe21fd4d93bd6",
                 "shasum": ""
             },
             "require": {
@@ -416,7 +416,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-05-28T14:44:12+00:00"
+            "time": "2026-06-05T09:00:01+00:00"
         },
         {
             "name": "rector/rector",
@@ -559,16 +559,16 @@
         },
         {
             "name": "webonyx/graphql-php",
-            "version": "v15.32.3",
+            "version": "v15.33.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/webonyx/graphql-php.git",
-                "reference": "993bf0bea17f870412ad8a90f60c41cb8d5f1145"
+                "reference": "b45921716927250f9adeeb93539639f9d8ca9fee"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/webonyx/graphql-php/zipball/993bf0bea17f870412ad8a90f60c41cb8d5f1145",
-                "reference": "993bf0bea17f870412ad8a90f60c41cb8d5f1145",
+                "url": "https://api.github.com/repos/webonyx/graphql-php/zipball/b45921716927250f9adeeb93539639f9d8ca9fee",
+                "reference": "b45921716927250f9adeeb93539639f9d8ca9fee",
                 "shasum": ""
             },
             "require": {
@@ -581,14 +581,14 @@
                 "amphp/http-server": "^2.1 || ^3",
                 "dms/phpunit-arraysubset-asserts": "dev-master",
                 "ergebnis/composer-normalize": "^2.28",
-                "friendsofphp/php-cs-fixer": "3.95.1",
+                "friendsofphp/php-cs-fixer": "3.95.7",
                 "mll-lab/php-cs-fixer-config": "5.13.0",
                 "nyholm/psr7": "^1.5",
                 "phpbench/phpbench": "^1.2",
                 "phpstan/extension-installer": "^1.1",
-                "phpstan/phpstan": "2.1.51",
+                "phpstan/phpstan": "2.2.2",
                 "phpstan/phpstan-phpunit": "2.0.16",
-                "phpstan/phpstan-strict-rules": "2.0.10",
+                "phpstan/phpstan-strict-rules": "2.0.11",
                 "phpunit/phpunit": "^9.5 || ^10.5.21 || ^11",
                 "psr/http-message": "^1 || ^2",
                 "react/http": "^1.6",
@@ -623,7 +623,7 @@
             ],
             "support": {
                 "issues": "https://github.com/webonyx/graphql-php/issues",
-                "source": "https://github.com/webonyx/graphql-php/tree/v15.32.3"
+                "source": "https://github.com/webonyx/graphql-php/tree/v15.33.0"
             },
             "funding": [
                 {
@@ -635,7 +635,7 @@
                     "type": "open_collective"
                 }
             ],
-            "time": "2026-04-24T13:49:35+00:00"
+            "time": "2026-06-14T13:24:11+00:00"
         }
     ],
     "aliases": [],


### PR DESCRIPTION
v3.1.18 Release for the following changes:

[CN-1211](https://tradecentric.atlassian.net/browse/CN-1211)
[CN-1235](https://tradecentric.atlassian.net/browse/CN-1235)

[CN-1121]: https://tradecentric.atlassian.net/browse/CN-1121?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CN-1235]: https://tradecentric.atlassian.net/browse/CN-1235?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[CN-1211]: https://tradecentric.atlassian.net/browse/CN-1211?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ