### PR TITLE
ci: warn on PRs when composer.json version is not bumped

### DIFF
--- a/.github/workflows/version-check.yml
+++ b/.github/workflows/version-check.yml
@@ -1,0 +1,56 @@
+name: Composer Version Check
+
+on:
+  pull_request:
+    branches:
+      - main
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  version-check:
+    name: Warn if composer.json version not bumped
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+        with:
+          fetch-depth: 0
+
+      - name: Compare composer.json version against base branch
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          BASE_REF: ${{ github.base_ref }}
+        run: |
+          MARKER="<!-- composer-version-check -->"
+
+          BASE_VERSION=$(git show "origin/${BASE_REF}:composer.json" 2>/dev/null | jq -r '.version // empty')
+          HEAD_VERSION=$(jq -r '.version // empty' composer.json)
+          echo "Base (${BASE_REF}) version: ${BASE_VERSION:-<none>}"
+          echo "Head version:               ${HEAD_VERSION:-<none>}"
+
+          if [ -z "$HEAD_VERSION" ]; then
+            echo "::warning file=composer.json::composer.json has no \"version\" field."
+            BODY=$(printf '%s\n\n⚠️ **composer.json has no `version` field.**' "$MARKER")
+          elif [ "$BASE_VERSION" = "$HEAD_VERSION" ]; then
+            echo "::warning file=composer.json::composer.json version ($HEAD_VERSION) was not bumped in this PR."
+            BODY=$(printf '%s\n\n⚠️ **`composer.json` version was not updated** — still `%s`.\n\nBump the `version` field before this change is tagged for release.' "$MARKER" "$HEAD_VERSION")
+          else
+            echo "composer.json version bumped: $BASE_VERSION -> $HEAD_VERSION"
+            BODY=$(printf '%s\n\n✅ **`composer.json` version updated:** `%s` → `%s`.' "$MARKER" "$BASE_VERSION" "$HEAD_VERSION")
+          fi
+
+          # Upsert a single sticky comment so repeated pushes don't spam the PR.
+          COMMENT_ID=$(gh api "repos/${REPO}/issues/${PR_NUMBER}/comments" \
+            --jq "map(select(.body | contains(\"$MARKER\"))) | .[0].id // empty")
+
+          if [ -n "$COMMENT_ID" ]; then
+            gh api -X PATCH "repos/${REPO}/issues/comments/${COMMENT_ID}" -f body="$BODY" >/dev/null
+          else
+            gh api -X POST "repos/${REPO}/issues/${PR_NUMBER}/comments" -f body="$BODY" >/dev/null
+          fi

--- a/.github/workflows/version-check.yml
+++ b/.github/workflows/version-check.yml
@@ -25,24 +25,30 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           REPO: ${{ github.repository }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
-          BASE_REF: ${{ github.base_ref }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
         run: |
           MARKER="<!-- composer-version-check -->"
 
-          BASE_VERSION=$(git show "origin/${BASE_REF}:composer.json" 2>/dev/null | jq -r '.version // empty')
-          HEAD_VERSION=$(jq -r '.version // empty' composer.json)
-          echo "Base (${BASE_REF}) version: ${BASE_VERSION:-<none>}"
-          echo "Head version:               ${HEAD_VERSION:-<none>}"
+          # Read both sides defensively: a missing file, ref, or malformed JSON
+          # must yield an empty string, never a non-zero exit (which -eo pipefail
+          # would otherwise turn into a hard step failure instead of a warning).
+          HEAD_JSON=$(cat composer.json 2>/dev/null || true)
+          BASE_JSON=$(git show "${BASE_SHA}:composer.json" 2>/dev/null || true)
+          HEAD_VERSION=$(printf '%s' "$HEAD_JSON" | jq -r '.version // empty' 2>/dev/null || true)
+          BASE_VERSION=$(printf '%s' "$BASE_JSON" | jq -r '.version // empty' 2>/dev/null || true)
+
+          echo "Base (${BASE_SHA}) version: ${BASE_VERSION:-<none>}"
+          echo "Head version:                ${HEAD_VERSION:-<none>}"
 
           if [ -z "$HEAD_VERSION" ]; then
-            echo "::warning file=composer.json::composer.json has no \"version\" field."
-            BODY=$(printf '%s\n\n⚠️ **composer.json has no `version` field.**' "$MARKER")
+            echo "::warning file=composer.json::composer.json has no readable \"version\" field."
+            BODY=$(printf '%s\n\n⚠️ **`composer.json` has no readable `version` field.**' "$MARKER")
           elif [ "$BASE_VERSION" = "$HEAD_VERSION" ]; then
             echo "::warning file=composer.json::composer.json version ($HEAD_VERSION) was not bumped in this PR."
             BODY=$(printf '%s\n\n⚠️ **`composer.json` version was not updated** — still `%s`.\n\nBump the `version` field before this change is tagged for release.' "$MARKER" "$HEAD_VERSION")
           else
-            echo "composer.json version bumped: $BASE_VERSION -> $HEAD_VERSION"
-            BODY=$(printf '%s\n\n✅ **`composer.json` version updated:** `%s` → `%s`.' "$MARKER" "$BASE_VERSION" "$HEAD_VERSION")
+            echo "composer.json version bumped: ${BASE_VERSION:-<none>} -> $HEAD_VERSION"
+            BODY=$(printf '%s\n\n✅ **`composer.json` version updated:** `%s` → `%s`.' "$MARKER" "${BASE_VERSION:-<none>}" "$HEAD_VERSION")
           fi
 
           # Upsert a single sticky comment so repeated pushes don't spam the PR.

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
             "dealerdirect/phpcodesniffer-composer-installer": true
         }
     },
-    "version": "3.1.19",
+    "version": "3.1.20",
     "require": {
         "php": "~7.3.0||~7.4.0||^8.0",
         "tradecentric/module-version": "*",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "23d6ea67d0d15d7e02a132f8b297417f",
+    "content-hash": "5693f06c29067c08f04e5e5c42ad888a",
     "packages": [
         {
             "name": "tradecentric/module-version",


### PR DESCRIPTION
Adds a new `version-check.yml` workflow that runs on PRs to `main`.

It compares the `version` field in `composer.json` on the PR head against the base branch:
- If the version was **not** bumped (or is missing), it emits a non-blocking `::warning::` annotation and posts a ⚠️ sticky PR comment.
- If it was bumped, the comment flips to ✅ `old → new`.

The comment is upserted via a hidden marker so repeated pushes update one comment instead of spamming the PR. The job is intentionally non-blocking (warning only).