### PR TITLE
[MAIN] CN-1348: PHP 8.5 compatibility fixes

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,8 @@
 TradeCentric - PunchOut
 ===========
+### 3.1.21 (2026-08-03)
+* CN-1348: Added support for PHP 8.5 compatibility with Magento 2.4.9
+
 ### 3.1.19 (2026-07-15)
 * PBR-2682: Fixed full SKU concatenation
 

--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -227,7 +227,7 @@ class Data extends \Magento\Framework\App\Helper\AbstractHelper
             ScopeInterface::SCOPE_STORE,
             $store
         );
-        if (!strlen($value)) {
+        if (!strlen((string) $value)) {
             return [];
         }
         return (array) $this->jsonSerializer->unserialize($value);
@@ -239,7 +239,7 @@ class Data extends \Magento\Framework\App\Helper\AbstractHelper
      */
     public function getRemoteInfoUrl(string $sessionId = '')
     {
-        return preg_replace('/{pos}/', $sessionId, $this->getValidateSessionUrl());
+        return preg_replace('/{pos}/', $sessionId, (string) $this->getValidateSessionUrl());
     }
 
     /**

--- a/Model/PunchoutSessionCollector/CustomerHandler/DataExtractors/BasicParams.php
+++ b/Model/PunchoutSessionCollector/CustomerHandler/DataExtractors/BasicParams.php
@@ -36,7 +36,7 @@ class BasicParams implements DataExtractorInterface
         }
         // set email for log use
         $result = [];
-        $result['email'] = trim($params['body']['contact']['email']);
+        $result['email'] = trim((string) ($params['body']['contact']['email'] ?? ''));
         $nameArray = $this->helper->getUserSplitName($params);
         $result['firstname'] = $nameArray[0];
         $result['lastname'] = $nameArray[1];

--- a/Model/Transfer/QuoteTransferData.php
+++ b/Model/Transfer/QuoteTransferData.php
@@ -79,7 +79,7 @@ class QuoteTransferData extends \Magento\Framework\DataObject implements Transfe
      */
     protected function assertSessionValid()
     {
-        if (!strlen($this->getData('cart/punchout_session_id'))) {
+        if (!strlen((string) $this->getData('cart/punchout_session_id'))) {
             throw new LocalizedException(__('Punchout session is not valid'));
         }
     }
@@ -89,7 +89,7 @@ class QuoteTransferData extends \Magento\Framework\DataObject implements Transfe
      */
     protected function assertUrlValid()
     {
-        if (!strlen($this->getData('cart/punchout_return_url'))) {
+        if (!strlen((string) $this->getData('cart/punchout_return_url'))) {
             throw new LocalizedException(__('Punchout url is not valid'));
         }
         if (!filter_var($this->getData('cart/punchout_return_url'), FILTER_VALIDATE_URL)) {

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
             "dealerdirect/phpcodesniffer-composer-installer": true
         }
     },
-    "version": "3.1.20",
+    "version": "3.1.21",
     "require": {
         "php": "~7.3.0||~7.4.0||^8.0",
         "tradecentric/module-version": "*",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "5693f06c29067c08f04e5e5c42ad888a",
+    "content-hash": "00c1868f30557ca869c7cebf59f13678",
     "packages": [
         {
             "name": "tradecentric/module-version",


### PR DESCRIPTION
## Summary
- Guard nullable config/data values with `(string)` casts before passing to `strlen()`, `trim()`, and `preg_replace()`, avoiding PHP 8.1+ deprecation notices that surface more loudly on PHP 8.5.

## Test plan
- Verified `bin/magento setup:di:compile` succeeds on PHP 8.5 + Adobe Commerce 2.4.9.
- See CN-1348 for full compatibility test plan across affected modules.